### PR TITLE
Fix TildeTransformer Causing Blanked Tokens

### DIFF
--- a/src/main/kotlin/com/beust/kash/TokenTransformer.kt
+++ b/src/main/kotlin/com/beust/kash/TokenTransformer.kt
@@ -92,7 +92,7 @@ class TildeTransformer: TokenTransformer {
                     it.replace("~", homeDir)
                 }
             } else {
-                words
+                words.toList()
             }
         return result
     }


### PR DESCRIPTION
## Issue + Cause
If you executed a command involving words surrounded by, for example, backticks:
```
> val a = "README.md"
> ls `a`
```
The token involving the surrounding word would be parsed to a blank word:
`[main] DEBUG com.beust.kash.Shell - Type(Command), Exec:SingleCommand(exec=Exec([Word("[ls]"), Word("`[]`")]))`.

![](https://i.imgur.com/G1dqlo5.png)



This was caused by the TildeTransformer just returning `words` back out of the transform function, so when `tokenTransformer` is executing this code:
```
tokenTransformers.forEach { t ->
            val transformed = t.transform(token, result) // second argument is words in TildeTransformer
            result.clear()
            result.addAll(transformed)
        }
```
`result` and `transformed` both refer to the same list, and so `result.clear()` clears both of them, causing the token to be blank thereon.

## Fix

Return a copy of the `words` list instead, so that the reference isn't the same.

![](http://i.imgur.com/QNqALmX.png)