### PR TITLE
Switch to Kotlin 1.3.40 and add dependencies resolving support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 buildscript {
-    val kotlinVer by extra { "1.3.31" }
+    val kotlinVer by extra { "1.3.40-eap-105" }
 
     repositories {
         jcenter()
@@ -19,20 +19,23 @@ repositories {
     jcenter()
     mavenCentral()
     maven { setUrl("https://plugins.gradle.org/m2") }
+    maven { setUrl("https://dl.bintray.com/kotlin/kotlin-eap") }
 }
 
 plugins {
     java
     application
     idea
-    id("org.jetbrains.kotlin.jvm") version "1.3.31"
+    id("org.jetbrains.kotlin.jvm") version "1.3.40-eap-105"
     id("com.github.johnrengelman.shadow") version "4.0.2"
 }
 
+val kotlinVer by extra { "1.3.40-eap-105" }
+
 dependencies {
-    listOf("org.jetbrains.kotlin:kotlin-compiler-embeddable:1.3.31",
-            "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:1.3.31",
-            "org.jetbrains.kotlin:kotlin-script-util:1.3.31",
+    listOf("org.jetbrains.kotlin:kotlin-compiler-embeddable:$kotlinVer",
+            "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:$kotlinVer",
+            "org.jetbrains.kotlin:kotlin-script-util:$kotlinVer",
             "org.jline:jline:3.11.0",
             "org.fusesource:fuse-project:7.2.0.redhat-060",
             "org.slf4j:slf4j-api:1.8.0-beta4",

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,6 +45,8 @@ dependencies {
     compile(kotlin("scripting-common", kotlinVer))
     compile(kotlin("scripting-jvm", kotlinVer))
     compile(kotlin("scripting-jvm-host-embeddable", kotlinVer))
+    compile(kotlin("main-kts", kotlinVer))
+    compile("org.apache.ivy:ivy:2.4.0")
     compile("com.beust:klaxon:5.0.5") {
         exclude("org.jetbrains.kotlin")
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,16 +33,18 @@ plugins {
 val kotlinVer by extra { "1.3.40-eap-105" }
 
 dependencies {
-    listOf("org.jetbrains.kotlin:kotlin-compiler-embeddable:$kotlinVer",
-            "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:$kotlinVer",
-            "org.jetbrains.kotlin:kotlin-script-util:$kotlinVer",
-            "org.jline:jline:3.11.0",
+    listOf("org.jline:jline:3.11.0",
             "org.fusesource:fuse-project:7.2.0.redhat-060",
             "org.slf4j:slf4j-api:1.8.0-beta4",
             "ch.qos.logback:logback-classic:1.3.0-alpha4"
             )
         .forEach { compile(it) }
 
+    compile(kotlin("compiler-embeddable", kotlinVer))
+    compile(kotlin("scripting-compiler-embeddable", kotlinVer))
+    compile(kotlin("scripting-common", kotlinVer))
+    compile(kotlin("scripting-jvm", kotlinVer))
+    compile(kotlin("scripting-jvm-host-embeddable", kotlinVer))
     compile("com.beust:klaxon:5.0.5") {
         exclude("org.jetbrains.kotlin")
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,7 @@
+
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        maven { url = uri("https://dl.bintray.com/kotlin/kotlin-eap") }
+    }
+}

--- a/src/main/kotlin/com/beust/kash/Shell.kt
+++ b/src/main/kotlin/com/beust/kash/Shell.kt
@@ -37,7 +37,7 @@ class Shell(terminal: Terminal): BuiltinContext, CommandRunner {
     private val KASH_STRINGS = listOf("Kash.ENV", "Kash.PATHS", "Kash.PROMPT", "Kash.DIRS")
 
     init {
-        val kotlinEngine = ScriptEngineManager().getEngineByExtension("kts")
+        val kotlinEngine = ScriptEngineManager().getEngineByExtension("kash.kts")
 
         //
         // Read Predef

--- a/src/main/kotlin/com/beust/kash/Shell.kt
+++ b/src/main/kotlin/com/beust/kash/Shell.kt
@@ -2,11 +2,6 @@ package com.beust.kash
 
 import com.beust.kash.Streams.readStream
 import kts.Engine
-import org.jetbrains.kotlin.cli.common.repl.KotlinJsr223JvmScriptEngineFactoryBase
-import org.jetbrains.kotlin.cli.common.repl.ScriptArgsWithTypes
-import org.jetbrains.kotlin.script.jsr223.KotlinJsr223JvmLocalScriptEngine
-import org.jetbrains.kotlin.script.jsr223.KotlinStandardJsr223ScriptTemplate
-import org.jetbrains.kotlin.script.util.scriptCompilationClasspathFromContextOrStlib
 import org.jline.reader.LineReader
 import org.jline.reader.LineReaderBuilder
 import org.jline.reader.impl.completer.StringsCompleter
@@ -19,9 +14,7 @@ import java.nio.file.Paths
 import java.util.*
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
-import javax.script.Bindings
-import javax.script.ScriptContext
-import javax.script.ScriptEngine
+import javax.script.ScriptEngineManager
 
 
 interface CommandRunner {
@@ -43,31 +36,8 @@ class Shell(terminal: Terminal): BuiltinContext, CommandRunner {
     private val PREDEF = "kts/Predef.kts"
     private val KASH_STRINGS = listOf("Kash.ENV", "Kash.PATHS", "Kash.PROMPT", "Kash.DIRS")
 
-    class MyScriptEngineFactory(private val classpath: List<File>) : KotlinJsr223JvmScriptEngineFactoryBase() {
-        override fun getScriptEngine(): ScriptEngine =
-                KotlinJsr223JvmLocalScriptEngine(
-                        this,
-                        classpath, // !!! supply the script classpath here
-                        KotlinStandardJsr223ScriptTemplate::class.qualifiedName!!,
-                        { ctx, types -> ScriptArgsWithTypes(arrayOf(ctx.getBindings(ScriptContext.ENGINE_SCOPE)), types ?: emptyArray()) },
-                        arrayOf(Bindings::class)
-                )
-    }
-
     init {
-        //
-        // Read ~/.kash.json, configure the classpath of the script engine
-        //
-        val dotKashReader = DotKashReader()
-        val userClasspath = dotKashReader.dotKash?.classpath?.map { File(it) } ?: emptyList()
-
-        val cp =
-                scriptCompilationClasspathFromContextOrStlib("kotlin-script-util.jar",
-                        wholeClasspath = true) +
-            userClasspath
-
-//        val kotlinEngine = ScriptEngineManager().getEngineByExtension("kts")
-        val kotlinEngine = MyScriptEngineFactory(cp).scriptEngine
+        val kotlinEngine = ScriptEngineManager().getEngineByExtension("kts")
 
         //
         // Read Predef

--- a/src/main/kotlin/com/beust/kash/script/ScriptDefinition.kt
+++ b/src/main/kotlin/com/beust/kash/script/ScriptDefinition.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the license/LICENSE.txt file.
+ */
+
+package com.beust.kash.script
+
+import org.jetbrains.kotlin.cli.common.repl.KOTLIN_SCRIPT_ENGINE_BINDINGS_KEY
+import org.jetbrains.kotlin.cli.common.repl.KOTLIN_SCRIPT_STATE_BINDINGS_KEY
+import javax.script.Bindings
+import javax.script.ScriptEngine
+import kotlin.script.experimental.annotations.KotlinScript
+import kotlin.script.templates.standard.ScriptTemplateWithBindings
+
+@Suppress("unused")
+@KotlinScript
+abstract class ScriptDefinition(val jsr223Bindings: Bindings) : ScriptTemplateWithBindings(jsr223Bindings) {
+
+    private val myEngine: ScriptEngine? get() = bindings[KOTLIN_SCRIPT_ENGINE_BINDINGS_KEY]?.let { it as? ScriptEngine }
+
+    private inline fun <T> withMyEngine(body: (ScriptEngine) -> T): T =
+        myEngine?.let(body) ?: throw IllegalStateException("Script engine for `eval` call is not found")
+
+    fun eval(script: String, newBindings: Bindings): Any? =
+        withMyEngine {
+            val savedState =
+                newBindings[KOTLIN_SCRIPT_STATE_BINDINGS_KEY]?.takeIf { it === this.jsr223Bindings[KOTLIN_SCRIPT_STATE_BINDINGS_KEY] }
+                    ?.apply {
+                        newBindings[KOTLIN_SCRIPT_STATE_BINDINGS_KEY] = null
+                    }
+            val res = it.eval(script, newBindings)
+            savedState?.apply {
+                newBindings[KOTLIN_SCRIPT_STATE_BINDINGS_KEY] = savedState
+            }
+            res
+        }
+
+    fun eval(script: String): Any? =
+        withMyEngine {
+            val savedState = jsr223Bindings.remove(KOTLIN_SCRIPT_STATE_BINDINGS_KEY)
+            val res = it.eval(script, jsr223Bindings)
+            savedState?.apply {
+                jsr223Bindings[KOTLIN_SCRIPT_STATE_BINDINGS_KEY] = savedState
+            }
+            res
+        }
+
+    fun createBindings(): Bindings = withMyEngine { it.createBindings() }
+}

--- a/src/main/kotlin/com/beust/kash/script/ScriptDefinition.kt
+++ b/src/main/kotlin/com/beust/kash/script/ScriptDefinition.kt
@@ -23,7 +23,11 @@ import kotlin.script.experimental.jvm.updateClasspath
 import kotlin.script.templates.standard.ScriptTemplateWithBindings
 
 @Suppress("unused")
-@KotlinScript(compilationConfiguration = CompilationConfiguration::class)
+@KotlinScript(
+    displayName = "kash script",
+    fileExtension = "kash.kts",
+    compilationConfiguration = CompilationConfiguration::class
+)
 abstract class ScriptDefinition(val jsr223Bindings: Bindings) : ScriptTemplateWithBindings(jsr223Bindings) {
 
     private val myEngine: ScriptEngine? get() = bindings[KOTLIN_SCRIPT_ENGINE_BINDINGS_KEY]?.let { it as? ScriptEngine }

--- a/src/main/kotlin/com/beust/kash/script/ScriptDefinition.kt
+++ b/src/main/kotlin/com/beust/kash/script/ScriptDefinition.kt
@@ -7,13 +7,23 @@ package com.beust.kash.script
 
 import org.jetbrains.kotlin.cli.common.repl.KOTLIN_SCRIPT_ENGINE_BINDINGS_KEY
 import org.jetbrains.kotlin.cli.common.repl.KOTLIN_SCRIPT_STATE_BINDINGS_KEY
+import org.jetbrains.kotlin.mainKts.impl.FilesAndIvyResolver
+import org.jetbrains.kotlin.script.util.DependsOn
+import org.jetbrains.kotlin.script.util.Repository
+import java.io.File
 import javax.script.Bindings
 import javax.script.ScriptEngine
+import kotlin.script.dependencies.ScriptContents
+import kotlin.script.dependencies.ScriptDependenciesResolver
 import kotlin.script.experimental.annotations.KotlinScript
+import kotlin.script.experimental.api.*
+import kotlin.script.experimental.jvm.compat.mapLegacyDiagnosticSeverity
+import kotlin.script.experimental.jvm.compat.mapLegacyScriptPosition
+import kotlin.script.experimental.jvm.updateClasspath
 import kotlin.script.templates.standard.ScriptTemplateWithBindings
 
 @Suppress("unused")
-@KotlinScript
+@KotlinScript(compilationConfiguration = CompilationConfiguration::class)
 abstract class ScriptDefinition(val jsr223Bindings: Bindings) : ScriptTemplateWithBindings(jsr223Bindings) {
 
     private val myEngine: ScriptEngine? get() = bindings[KOTLIN_SCRIPT_ENGINE_BINDINGS_KEY]?.let { it as? ScriptEngine }
@@ -47,3 +57,53 @@ abstract class ScriptDefinition(val jsr223Bindings: Bindings) : ScriptTemplateWi
 
     fun createBindings(): Bindings = withMyEngine { it.createBindings() }
 }
+
+object CompilationConfiguration : ScriptCompilationConfiguration(
+    {
+        defaultImports(DependsOn::class, Repository::class)
+        refineConfiguration {
+            onAnnotations(DependsOn::class, Repository::class, handler = ConfigurationRefiner())
+        }
+        ide {
+            acceptedLocations(ScriptAcceptedLocation.Everywhere)
+        }
+    })
+
+class ConfigurationRefiner : RefineScriptCompilationConfigurationHandler {
+    private val resolver = FilesAndIvyResolver()
+
+    override operator fun invoke(context: ScriptConfigurationRefinementContext): ResultWithDiagnostics<ScriptCompilationConfiguration> {
+        val diagnostics = arrayListOf<ScriptDiagnostic>()
+
+        fun report(severity: ScriptDependenciesResolver.ReportSeverity, message: String, position: ScriptContents.Position?) {
+            diagnostics.add(
+                    ScriptDiagnostic(
+                            message,
+                            mapLegacyDiagnosticSeverity(severity),
+                            context.script.locationId,
+                            mapLegacyScriptPosition(position)
+                    )
+            )
+        }
+
+        val annotations = context.collectedData?.get(ScriptCollectedData.foundAnnotations)?.takeIf { it.isNotEmpty() }
+                ?: return context.compilationConfiguration.asSuccess()
+
+        val resolvedClassPath = try {
+            val scriptContents = object : ScriptContents {
+                override val annotations: Iterable<Annotation> = annotations.filter { it is DependsOn || it is Repository }
+                override val file: File? = null
+                override val text: CharSequence? = null
+            }
+            resolver.resolve(scriptContents, emptyMap(), ::report, null).get()?.classpath?.toList()
+            // TODO: add diagnostics
+        } catch (e: Throwable) {
+            return ResultWithDiagnostics.Failure(*diagnostics.toTypedArray(), e.asDiagnostics(path = context.script.locationId))
+        }
+
+        return ScriptCompilationConfiguration(context.compilationConfiguration) {
+            if (resolvedClassPath != null) updateClasspath(resolvedClassPath)
+        }.asSuccess(diagnostics)
+    }
+}
+

--- a/src/main/kotlin/com/beust/kash/script/ScriptEngineFactory.kt
+++ b/src/main/kotlin/com/beust/kash/script/ScriptEngineFactory.kt
@@ -23,6 +23,8 @@ class ScriptEngineFactory : KotlinJsr223JvmScriptEngineFactoryBase() {
     private val compilationConfiguration = createJvmCompilationConfigurationFromTemplate<ScriptDefinition>()
     private val evaluationConfiguration = createJvmEvaluationConfigurationFromTemplate<ScriptDefinition>()
 
+    override fun getExtensions(): List<String> = listOf("kash.kts")
+
     @Synchronized
     protected fun JvmScriptCompilationConfigurationBuilder.calculateClasspath() {
         //

--- a/src/main/kotlin/com/beust/kash/script/ScriptEngineFactory.kt
+++ b/src/main/kotlin/com/beust/kash/script/ScriptEngineFactory.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the license/LICENSE.txt file.
+ */
+
+package com.beust.kash.script
+
+import com.beust.kash.DotKashReader
+import org.jetbrains.kotlin.cli.common.repl.KotlinJsr223JvmScriptEngineFactoryBase
+import java.io.File
+import javax.script.ScriptEngine
+import kotlin.script.experimental.api.ScriptCompilationConfiguration
+import kotlin.script.experimental.jvm.JvmScriptCompilationConfigurationBuilder
+import kotlin.script.experimental.jvm.jvm
+import kotlin.script.experimental.jvm.updateClasspath
+import kotlin.script.experimental.jvm.util.scriptCompilationClasspathFromContext
+import kotlin.script.experimental.jvmhost.createJvmCompilationConfigurationFromTemplate
+import kotlin.script.experimental.jvmhost.createJvmEvaluationConfigurationFromTemplate
+import kotlin.script.experimental.jvmhost.jsr223.KotlinJsr223ScriptEngineImpl
+
+class ScriptEngineFactory : KotlinJsr223JvmScriptEngineFactoryBase() {
+
+    private val compilationConfiguration = createJvmCompilationConfigurationFromTemplate<ScriptDefinition>()
+    private val evaluationConfiguration = createJvmEvaluationConfigurationFromTemplate<ScriptDefinition>()
+
+    @Synchronized
+    protected fun JvmScriptCompilationConfigurationBuilder.calculateClasspath() {
+        //
+        // Read ~/.kash.json, configure the classpath of the script engine
+        //
+        val dotKashReader = DotKashReader()
+        val userClasspath = dotKashReader.dotKash?.classpath?.map { File(it) } ?: emptyList()
+
+        val currentClassLoader = Thread.currentThread().contextClassLoader
+        val classPath =
+            scriptCompilationClasspathFromContext(
+                classLoader = currentClassLoader,
+                wholeClasspath = true,
+                unpackJarCollections = true
+            ) + userClasspath
+        updateClasspath(classPath)
+    }
+
+    override fun getScriptEngine(): ScriptEngine =
+        KotlinJsr223ScriptEngineImpl(
+            this,
+            ScriptCompilationConfiguration(compilationConfiguration) {
+                jvm {
+                    calculateClasspath()
+                }
+            },
+            evaluationConfiguration
+        )
+}
+

--- a/src/main/resources/META-INF/services/javax.script.ScriptEngineFactory
+++ b/src/main/resources/META-INF/services/javax.script.ScriptEngineFactory
@@ -1,1 +1,1 @@
-org.jetbrains.kotlin.script.jsr223.KotlinJsr223JvmLocalScriptEngineFactory
+com.beust.kash.script.ScriptEngineFactory

--- a/src/test/kotlin/com/beust/kash/ScriptTest.kt
+++ b/src/test/kotlin/com/beust/kash/ScriptTest.kt
@@ -1,0 +1,39 @@
+package com.beust.kash
+
+import org.assertj.core.api.Assertions.assertThat
+import org.testng.annotations.Test
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import javax.script.ScriptEngine
+import javax.script.ScriptEngineManager
+
+@Test
+class ScriptTest {
+    private val kotlinEngine = ScriptEngineManager().getEngineByExtension("kts")
+
+    fun dependsOn() {
+        val result = kotlinEngine.evalScript("""
+            @file:DependsOn("log4j:log4j:1.2.12")
+            val log = org.apache.log4j.Logger.getRootLogger()
+            println(log.name)
+            """.trimIndent())
+        assertThat(result).isEqualTo(listOf("root"))
+    }
+}
+
+private fun ScriptEngine.evalScript(script: String): List<String> = captureOut {
+    eval(script)
+}
+
+private fun captureOut(body: () -> Unit): List<String> {
+    val outStream = ByteArrayOutputStream()
+    val prevOut = System.out
+    System.setOut(PrintStream(outStream))
+    try {
+        body()
+    } finally {
+        System.out.flush()
+        System.setOut(prevOut)
+    }
+    return outStream.toString().split('\r', '\n').mapNotNull { it.trim().takeIf { it.isNotEmpty() } }
+}

--- a/src/test/kotlin/com/beust/kash/ScriptTest.kt
+++ b/src/test/kotlin/com/beust/kash/ScriptTest.kt
@@ -9,7 +9,7 @@ import javax.script.ScriptEngineManager
 
 @Test
 class ScriptTest {
-    private val kotlinEngine = ScriptEngineManager().getEngineByExtension("kts")
+    private val kotlinEngine = ScriptEngineManager().getEngineByExtension("kash.kts")
 
     fun dependsOn() {
         val result = kotlinEngine.evalScript("""


### PR DESCRIPTION
A working example (or ready to merge PR, if you like) of using Kotlin 1.3.40 scripting/REPL/jsr-223 infrastructure for adding support for dependency resolving.
Comments to each commit:

- Switch to Kotlin 1.3.40-eap-105 - is trivial

- Switch to the new JSR-223 impl - I copied a top level part of the new JSR-223 implementation from Kotlin and modified it accordingly. I also moved the functionality of user classpath configuration from your Shell class to this JSR-223 script engine factory

- Add configuration refiner ... - I copied the configuration refinement handler from `kotlin-main-kts` project, removed support for `Import` annotation from it (it doesn't work yet for the JSR-223-based scripts), and made a few other modifications. I also added a test that shows `DependsOn` annotation usage. (Another supported annotation - `Repository` - is not covered with tests here yet.) The resolving is based on the minimal ivy-based resolver, which is distributed with `kotlin-main-kts` fat jar. It is of course possible to make the same logic with maven aether or anything else.

- Add dedicated kash script... - added configuration bits to allow to use kash jar as a source of `.kash.kts` scripts support in Intellij IDEA. This support is not tested yet.